### PR TITLE
Add further Go files to the makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ all: wasm-stl-viewer
 wasm-stl-viewer: bundle.wasm main.go
 	go build -o wasm-stl-viewer main.go
 
-bundle.wasm: bundle.go
+bundle.wasm: bundle.go color/color.go color/gradient.go color/interpolation.go gltypes/gltypes.go models/model.go models/stl.go renderer/renderer.go
 	GOOS=js GOARCH=wasm go build -o bundle.wasm bundle.go
 
 run: bundle.wasm wasm-stl-viewer


### PR DESCRIPTION
This allows make to trigger builds when any of the Go source files is updated, not just bundle.go.